### PR TITLE
Add namespace to rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+- Add "plugin" namespace to rule to fix stylelint deprecation warning.
+
 ## 2.0.1
 
 - Loosen stylelint version range to allow for v4 (or anything higher than 3).

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Like so:
     // ...
     // The following settings = max nesting depth of 1,
     // with the option `countAtRules` set to `false`
-    "statement-max-nesting-depth": [1, { countAtRules: false }],
+    "plugin/statement-max-nesting-depth": [1, { countAtRules: false }],
     // ...
   },
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var assign = require('object-assign');
 var stylelint = require('stylelint');
 
-var ruleName = 'statement-max-nesting-depth';
+var ruleName = 'plugin/statement-max-nesting-depth';
 
 var messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: 'Nesting exceeds maximum nesting depth',


### PR DESCRIPTION
Fixes deprecation warning: "Plugin rules that aren't namespaced have been deprecated, and in 7.0 they will be disallowed"
